### PR TITLE
use feature, no warnings

### DIFF
--- a/v534/try-catch.pl
+++ b/v534/try-catch.pl
@@ -7,10 +7,12 @@ use v5.34;
 my $e = eval { 1/0 };
 print "exception: $@\n" if $@;
 
+use feature 'try';
+no warnings "experimental::try";
+
 # Perl v5.34 introduced try/catch block.
 try {
-    1/0;
-} catch {
-    my $e = shift;
+    my $x = 1/0;
+} catch ($e) {
     print "try/catch exception: $e\n";
 }


### PR DESCRIPTION
In [FB post](https://www.facebook.com/groups/perlcommunity/posts/1214204346053856/) the sample wasn't actually using the new feature, as can be seen by the lack of an Experimental Feature warning.

Syntax requires `catch ($e) {` without a my , no `shift` needed. Go figure? But it is what it is.